### PR TITLE
Create document recipient confirm component

### DIFF
--- a/src/components/ETaxInvoiceForm.vue
+++ b/src/components/ETaxInvoiceForm.vue
@@ -14,6 +14,7 @@
         <h1>ใบกำกับภาษีอิเล็กทรอนิกส์</h1>
         <seller-info-confirm :sellerConfirmProp="seller"></seller-info-confirm>
         <recipient-info-confirm :recipientConfirmProp="recipient"></recipient-info-confirm>
+        <document-recipient-info-confirm :documentRecipientConfirmProp="documentRecipient"></document-recipient-info-confirm>
      </div>
    </div>
 </template>
@@ -24,6 +25,7 @@ import SellerData from '@/data/Seller.data.js'
 import RecipientInfoConfirm from '@/components/confirm_pages/RecipientInfoConfirm.vue'
 import RecipientInfoForm from '@/components/form_pages/RecipientInfoForm.vue'
 import RecipientData from '@/data/Recipient.data.js'
+import DocumentRecipientInfoConfirm from '@/components/confirm_pages/DocumentRecipientInfoConfirm.vue'
 import DocumentRecipientInfoForm from '@/components/form_pages/DocumentRecipientInfoForm.vue'
 import DocumentRecipientData from '@/data/DocumentRecipient.data.js'
 
@@ -41,7 +43,8 @@ export default {
     SellerInfoConfirm,
     RecipientInfoForm,
     RecipientInfoConfirm,
-    DocumentRecipientInfoForm
+    DocumentRecipientInfoForm,
+    DocumentRecipientInfoConfirm
   },
   methods: {
   }

--- a/src/components/confirm_pages/DocumentRecipientInfoConfirm.vue
+++ b/src/components/confirm_pages/DocumentRecipientInfoConfirm.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="InvoiceeInfoConfirm">
+    <h2>ผู้รับเอกสาร</h2>
+      <!--Invoicee Trade Party-->
+      รหัสผู้ค้า(ผู้รับเอกสาร) : <span>{{ documentRecipientConfirmProp.id }}</span><br>
+      รหัสผู้ค้าสากล(ผู้รับเอกสาร) : <span>{{ documentRecipientConfirmProp.globalID }}</span><br>
+      ชื่อผู้ขาย : <span>{{ documentRecipientConfirmProp.name }}</span><br>
+      <!--Specified Tax Registration-->
+      เลขประจำตัวผู้เสียภาษีอากร : <span>{{ documentRecipientConfirmProp.taxID }}</span><br>
+      <!--Defined Trade Contact-->
+      ชื่อผู้ติดต่อ: <span>{{ documentRecipientConfirmProp.personName }}</span><br>
+      ชื่อแผนก: <span>{{ documentRecipientConfirmProp.departmentName }}</span><br>
+      <!--E-mail URI Universal Communication-->
+      อีเมล: <span>{{ documentRecipientConfirmProp.email }}</span><br>
+      <!--Telephone Universal Communication -->
+      เบอร์โทรศัพท์: <span>{{ documentRecipientConfirmProp.phoneNumber }}</span><br>
+      <!--Postal Trade Address -->
+      รหัสไปรษณีย์: <span>{{ documentRecipientConfirmProp.postalCode }}</span><br>
+      ชื่ออาคาร: <span>{{ documentRecipientConfirmProp.building }}</span><br>
+      ที่อยู่บรรทัดที่ 1: <span>{{ documentRecipientConfirmProp.addressLineOne }}</span><br>
+      ที่อยู่บรรทัดที่ 2: <span>{{ documentRecipientConfirmProp.addressLineTwo }}</span><br>
+      ซอย: <span>{{ documentRecipientConfirmProp.addressLineThree }}</span><br>
+      หมู่บ้าน: <span>{{ documentRecipientConfirmProp.addressLineFour }}</span><br>
+      หมู่ที่: <span>{{ documentRecipientConfirmProp.addressLineFive }}</span><br>
+      ถนน: <span>{{ documentRecipientConfirmProp.street }}</span><br>
+      ชื่ออำเภอ: <span>{{ documentRecipientConfirmProp.district }}</span><br>
+      ชื่อตำบล: <span>{{ documentRecipientConfirmProp.subDistrict }}</span><br>
+      รหัสประเทศ: <span>{{ documentRecipientConfirmProp.countryID }}</span><br>
+      รหัสจังหวัด: <span>{{ documentRecipientConfirmProp.provinceID }}</span><br>
+      บ้านเลขที่: <span>{{ documentRecipientConfirmProp.houseNumber }}</span><br>
+   </div>
+</template>
+<script>
+export default {
+  props: ['documentRecipientConfirmProp']
+}
+</script>


### PR DESCRIPTION
@champillon 
Create document recipient confirm component. (DocumentRecipientInfoConfirm.vue, ETaxInvoiceForm.vue).
Previous PR that work together with this PR, please see [here](https://github.com/it-kmitl-2018/group8-frontend/pull/63).
Note : According to requirement document, it Thai, this call 'ผู้รับเอกสาร'.