### PR TITLE
Split form and confirm page

### DIFF
--- a/src/components/ETaxInvoiceConfirm.vue
+++ b/src/components/ETaxInvoiceConfirm.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="ETaxInvoiceConfirm">
+    <h1> โปรดตรวจสอบข้อมูลดังกล่าวว่าถูกต้องหรือไม่ </h1>
+    <h1>ใบกำกับภาษีอิเล็กทรอนิกส์</h1>
+    <seller-info-confirm :sellerConfirmProp="seller"></seller-info-confirm>
+    <recipient-info-confirm :recipientConfirmProp="recipient"></recipient-info-confirm>
+    <document-recipient-info-confirm :documentRecipientConfirmProp="documentRecipient"></document-recipient-info-confirm>
+  </div>
+</template>
+<script>
+import SellerInfoConfirm from '@/components/confirm_pages/SellerInfoConfirm.vue'
+import SellerData from '@/data/Seller.data.js'
+import RecipientInfoConfirm from '@/components/confirm_pages/RecipientInfoConfirm.vue'
+import RecipientData from '@/data/Recipient.data.js'
+import DocumentRecipientInfoConfirm from '@/components/confirm_pages/DocumentRecipientInfoConfirm.vue'
+import DocumentRecipientData from '@/data/DocumentRecipient.data.js'
+
+export default {
+  data () {
+    return {
+      buttonIsSubmitted: false,
+      seller: SellerData.data,
+      recipient: RecipientData.data,
+      documentRecipient: DocumentRecipientData.data
+    }
+  },
+  components: {
+    SellerInfoConfirm,
+    RecipientInfoConfirm,
+    DocumentRecipientInfoConfirm
+  },
+  methods: {
+  }
+}
+</script>

--- a/src/components/ETaxInvoiceForm.vue
+++ b/src/components/ETaxInvoiceForm.vue
@@ -29,7 +29,7 @@ export default {
   components: {
     SellerInfoForm,
     RecipientInfoForm,
-    DocumentRecipientInfoForm,
+    DocumentRecipientInfoForm
   },
   methods: {
   }

--- a/src/components/ETaxInvoiceForm.vue
+++ b/src/components/ETaxInvoiceForm.vue
@@ -1,38 +1,26 @@
 <template>
    <div class="ETaxInvoiceForm">
-     <div v-if="buttonIsSubmitted===false">
-       <br>
-       <h1>ใบกำกับภาษีอิเล็กทรอนิกส์</h1>
-       <seller-info-form :sellerFormProp="seller"></seller-info-form>
-       <recipient-info-form :recipientFormProp="recipient"></recipient-info-form>
-       <document-recipient-info-form :documentRecipientFormProp="documentRecipient"></document-recipient-info-form>
-       <button @click="buttonIsSubmitted=true"> ส่งข้อมูล </button>
-     </div>
-     <div v-else>
-        <h1> โปรดตรวจสอบข้อมูลดังกล่าวว่าถูกต้องหรือไม่ </h1>
-        <!--Guideline Specified CI Document Context Parameter -->
-        <h1>ใบกำกับภาษีอิเล็กทรอนิกส์</h1>
-        <seller-info-confirm :sellerConfirmProp="seller"></seller-info-confirm>
-        <recipient-info-confirm :recipientConfirmProp="recipient"></recipient-info-confirm>
-        <document-recipient-info-confirm :documentRecipientConfirmProp="documentRecipient"></document-recipient-info-confirm>
-     </div>
+      <br>
+      <h1>ใบกำกับภาษีอิเล็กทรอนิกส์</h1>
+      <seller-info-form :sellerFormProp="seller"></seller-info-form>
+      <recipient-info-form :recipientFormProp="recipient"></recipient-info-form>
+      <document-recipient-info-form :documentRecipientFormProp="documentRecipient"></document-recipient-info-form>
+      <router-link :to="{name: 'ETaxInvoiceConfirm'}">
+        <button> ส่งข้อมูล </button>
+      </router-link>
    </div>
 </template>
 <script>
-import SellerInfoConfirm from '@/components/confirm_pages/SellerInfoConfirm.vue'
 import SellerInfoForm from '@/components/form_pages/SellerInfoForm.vue'
 import SellerData from '@/data/Seller.data.js'
-import RecipientInfoConfirm from '@/components/confirm_pages/RecipientInfoConfirm.vue'
 import RecipientInfoForm from '@/components/form_pages/RecipientInfoForm.vue'
 import RecipientData from '@/data/Recipient.data.js'
-import DocumentRecipientInfoConfirm from '@/components/confirm_pages/DocumentRecipientInfoConfirm.vue'
 import DocumentRecipientInfoForm from '@/components/form_pages/DocumentRecipientInfoForm.vue'
 import DocumentRecipientData from '@/data/DocumentRecipient.data.js'
 
 export default {
   data () {
     return {
-      buttonIsSubmitted: false,
       seller: SellerData.data,
       recipient: RecipientData.data,
       documentRecipient: DocumentRecipientData.data
@@ -40,11 +28,8 @@ export default {
   },
   components: {
     SellerInfoForm,
-    SellerInfoConfirm,
     RecipientInfoForm,
-    RecipientInfoConfirm,
     DocumentRecipientInfoForm,
-    DocumentRecipientInfoConfirm
   },
   methods: {
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import ETaxInvoiceForm from '@/components/ETaxInvoiceForm'
+import ETaxInvoiceConfirm from '@/components/ETaxInvoiceConfirm'
 
 Vue.use(Router)
 
@@ -10,6 +11,11 @@ export default new Router({
       path: '/ETaxInvoiceForm',
       name: 'ETaxInvoiceForm',
       component: ETaxInvoiceForm
+    },
+    {
+      path: '/ETaxInvoiceConfirm',
+      name: 'ETaxInvoiceConfirm',
+      component: ETaxInvoiceConfirm
     }
   ]
 })


### PR DESCRIPTION
@champillon @pangaunn 
Split form and confirm page (ETaxinvoiceForm.vue, ETaxInvoiceConfirm.vue).

Note : According to @champillon comment (see [here](https://github.com/it-kmitl-2018/group8-frontend/pull/64#pullrequestreview-109563205)) about ETaxInvoiceForm page which contain two components (form and confirm components) in the same page. I decided to split into two pages using vue-router, which would make it easier to maintain in future.