### PR TITLE
Create payee confirm component

### DIFF
--- a/src/components/ETaxInvoiceConfirm.vue
+++ b/src/components/ETaxInvoiceConfirm.vue
@@ -24,7 +24,7 @@ export default {
       buttonIsSubmitted: false,
       seller: SellerData.data,
       recipient: RecipientData.data,
-      documentRecipient: DocumentRecipientData.data
+      documentRecipient: DocumentRecipientData.data,
       payee: PayeeData.data
     }
   },

--- a/src/components/ETaxInvoiceConfirm.vue
+++ b/src/components/ETaxInvoiceConfirm.vue
@@ -5,6 +5,7 @@
     <seller-info-confirm :sellerConfirmProp="seller"></seller-info-confirm>
     <recipient-info-confirm :recipientConfirmProp="recipient"></recipient-info-confirm>
     <document-recipient-info-confirm :documentRecipientConfirmProp="documentRecipient"></document-recipient-info-confirm>
+    <payee-info-confirm :payeeConfirmProp="payee"></payee-info-confirm>
   </div>
 </template>
 <script>
@@ -14,6 +15,8 @@ import RecipientInfoConfirm from '@/components/confirm_pages/RecipientInfoConfir
 import RecipientData from '@/data/Recipient.data.js'
 import DocumentRecipientInfoConfirm from '@/components/confirm_pages/DocumentRecipientInfoConfirm.vue'
 import DocumentRecipientData from '@/data/DocumentRecipient.data.js'
+import PayeeInfoConfirm from '@/components/confirm_pages/PayeeInfoConfirm.vue'
+import PayeeData from '@/data/Payee.data.js'
 
 export default {
   data () {
@@ -22,12 +25,14 @@ export default {
       seller: SellerData.data,
       recipient: RecipientData.data,
       documentRecipient: DocumentRecipientData.data
+      payee: PayeeData.data
     }
   },
   components: {
     SellerInfoConfirm,
     RecipientInfoConfirm,
-    DocumentRecipientInfoConfirm
+    DocumentRecipientInfoConfirm,
+    PayeeInfoConfirm
   },
   methods: {
   }

--- a/src/components/ETaxInvoiceConfirm.vue
+++ b/src/components/ETaxInvoiceConfirm.vue
@@ -21,7 +21,6 @@ import PayeeData from '@/data/Payee.data.js'
 export default {
   data () {
     return {
-      buttonIsSubmitted: false,
       seller: SellerData.data,
       recipient: RecipientData.data,
       documentRecipient: DocumentRecipientData.data,

--- a/src/components/confirm_pages/PayeeInfoConfirm.vue
+++ b/src/components/confirm_pages/PayeeInfoConfirm.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="PayeeInfoConfirm">
+    <h2>ผู้รับชำระเงิน</h2>
+      <!--Seller Trade Party-->
+      รหัสผู้ค้า(ผู้รับชำระเงิน) : <span>{{ payeeConfirmProp.id }}</span><br>
+      รหัสผู้ค้าสากล(ผู้รับชำระเงิน) : <span>{{ payeeConfirmProp.globalID }}</span><br>
+      ชื่อผู้ขาย : <span>{{ payeeConfirmProp.name }}</span><br>
+      <!--Specified Tax Registration-->
+      เลขประจำตัวผู้เสียภาษีอากร : <span>{{ payeeConfirmProp.taxID }}</span><br>
+      <!--Defined Trade Contact-->
+      ชื่อผู้ติดต่อ: <span>{{ payeeConfirmProp.personName }}</span><br>
+      ชื่อแผนก: <span>{{ payeeConfirmProp.departmentName }}</span><br>
+      <!--E-mail URI Universal Communication-->
+      อีเมล: <span>{{ payeeConfirmProp.email }}</span><br>
+      <!--Telephone Universal Communication -->
+      เบอร์โทรศัพท์: <span>{{ payeeConfirmProp.phoneNumber }}</span><br>
+      <!--Postal Trade Address -->
+      รหัสไปรษณีย์: <span>{{ payeeConfirmProp.postalCode }}</span><br>
+      ชื่ออาคาร: <span>{{ payeeConfirmProp.building }}</span><br>
+      ที่อยู่บรรทัดที่ 1: <span>{{ payeeConfirmProp.addressLineOne }}</span><br>
+      ที่อยู่บรรทัดที่ 2: <span>{{ payeeConfirmProp.addressLineTwo }}</span><br>
+      ซอย: <span>{{ payeeConfirmProp.addressLineThree }}</span><br>
+      หมู่บ้าน: <span>{{ payeeConfirmProp.addressLineFour }}</span><br>
+      หมู่ที่: <span>{{ payeeConfirmProp.addressLineFive }}</span><br>
+      ถนน: <span>{{ payeeConfirmProp.street }}</span><br>
+      ชื่ออำเภอ: <span>{{ payeeConfirmProp.district }}</span><br>
+      ชื่อตำบล: <span>{{ payeeConfirmProp.subDistrict }}</span><br>
+      รหัสประเทศ: <span>{{ payeeConfirmProp.countryID }}</span><br>
+      รหัสจังหวัด: <span>{{ payeeConfirmProp.provinceID }}</span><br>
+      บ้านเลขที่: <span>{{ payeeConfirmProp.houseNumber }}</span><br>
+   </div>
+</template>
+<script>
+export default {
+  props: ['payeeConfirmProp']
+}
+</script>


### PR DESCRIPTION
Create payee form component. (ETaxinvoiceConfirm.vue, PayeeInfoConfirm.vue)
Note : According to requirement document, in Thai, this call 'ผู้รับชำระเงิน'.
Note 2 : This PR still not include facade pattern.
@champillon @pangaunn